### PR TITLE
Fix 404 for tags on blog posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,37 @@ categories: [Announcements, Learn, Events, Customers, Videos]
 ```
 
 More info can be found in the [official docs](http://jekyllrb.com/docs/posts/).
+
+## Using categories & adding new ones
+
+When adding a category to a blog post please remember to capitalise words.
+
+The current list of categories:
+- Announcements
+- Community
+- Customers
+- Events
+- GitHub
+- JavaScript
+- Learn
+- New Year
+- NodeJS
+- Notice
+- PHP
+- Release
+- SDK
+- Security
+- Update
+- Videos
+
+If you would like to use a new category please make a new file in blog > categories e.g:
+```
+---
+layout: blog
+permalink: /blog/categories/announcements/
+pagination:
+    enabled: true
+    category: Announcements
+    permalink: /:num/
+---
+```

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ More info can be found in the [official docs](http://jekyllrb.com/docs/posts/).
 
 ## Using categories & adding new ones
 
-When adding a category to a blog post please remember to capitalise words.
+When adding a category to a blog post please remember to capitalize words.
 
 The current list of categories:
 - Announcements

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Everything but name is optional.
 
 ## Authoring an Article
 
-To generate a new post, create a new file in the `_posts` directory. Be sure to add your name as the author of the post and include several [categories](#Using categories & adding new ones) if appropriate. Here is a sample header:
+To generate a new post, create a new file in the `_posts` directory. Be sure to add your name as the author of the post and include several [categories](#using-categories--adding-new-ones) if appropriate. Here is a sample header:
 
 ```yaml
 layout: post

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Everything but name is optional.
 
 ## Authoring an Article
 
-To generate a new post, create a new file in the `_posts` directory. Be sure to add your name as the author of the post and include several categories to file the post under. Here is a sample header:
+To generate a new post, create a new file in the `_posts` directory. Be sure to add your name as the author of the post and include several [categories](#Using categories & adding new ones) if appropriate. Here is a sample header:
 
 ```yaml
 layout: post
@@ -75,8 +75,8 @@ The current list of categories:
 - Update
 - Videos
 
-If you would like to use a new category please make a new file in blog > categories e.g:
-```
+If you would like to use a new category please make a new file in the [categories folder](blog/categories), for example:
+```yaml
 ---
 layout: blog
 permalink: /blog/categories/announcements/

--- a/_posts/2017-09-08-php-release-1.3.0.md
+++ b/_posts/2017-09-08-php-release-1.3.0.md
@@ -4,7 +4,7 @@ title: Parse PHP SDK Release 1.3.0
 date: 2017-09-08 11:02 -0700
 comments: true
 author: montymxb
-categories: [PHP, SDK, Release, 1.3.0, HHVM, fullText]
+categories: [PHP, SDK, Release]
 ---
 
 Version 1.3.0 of the Parse PHP SDK is [now available](https://github.com/parse-community/parse-php-sdk/releases/tag/1.3.0) for use.

--- a/_posts/2017-10-18-hacktoberfest.md
+++ b/_posts/2017-10-18-hacktoberfest.md
@@ -4,10 +4,10 @@ title: It's Hacktoberfest 2017!
 date: 2017-10-18 08:28 -0700
 comments: true
 author: montymxb
-categories: [open source, hacktoberfest, github]
+categories: [Hacktoberfest, GitHub]
 ---
 
-Hacktoberfest 2017 is underway! 
+Hacktoberfest 2017 is underway!
 
 We encourage you to take the time to sign up for Hacktoberfest and start contributing to parse-server or other open source projects on github.
 You can find more details and signup [here](https://hacktoberfest.digitalocean.com/), oh and did we mention there are free t-shirts?
@@ -23,10 +23,10 @@ They're all open source, they all count, and as usual any help is always appreci
 If you're looking for more specific ways to get started check out [hacktoberfest tagged issues](https://github.com/search?l=&q=state:open+label:hacktoberfest&ref=advsearch&type=Issues&utf8=%E2%9C%93), which are ideal to jump in on.
 Additionally here are some other [projects](https://hacktoberfest.digitalocean.com/#projects) that are recommended to get started with.
 
-Wherever you choose to help you can know you're improving open source for everyone. 
+Wherever you choose to help you can know you're improving open source for everyone.
 You can even take the time to pat yourself on the back (or raise a glass) in honor of your good deeds!
 However you choose to spend it we hope you'll enjoy the experience and continue to contribute on until next Hacktoberfest comes around.
 
 For those who are curious here's the github [blog post](https://github.com/blog/2260-hacktoberfest-is-back) on Hacktoberfest as well.
-With there only being about 2 weeks left it's time to roll up your sleeves and get hacking! 
+With there only being about 2 weeks left it's time to roll up your sleeves and get hacking!
 Don't forget to have a blast (and a beer) while you're at it. Have a happy Hacktoberfest!

--- a/_posts/2017-12-05-php-release-1.4.0.md
+++ b/_posts/2017-12-05-php-release-1.4.0.md
@@ -4,7 +4,7 @@ title: Parse PHP SDK Release 1.4.0
 date: 2017-12-05 20:24 -0700
 comments: true
 author: montymxb
-categories: [PHP, SDK, Release, 1.4.0]
+categories: [PHP, SDK, Release]
 ---
 
 Version 1.4.0 of the Parse PHP SDK is [now available](https://github.com/parse-community/parse-php-sdk/releases/tag/1.4.0) for use.
@@ -26,7 +26,7 @@ Here are some of the major changes that were made in this release.
 - Adds Purge & Polygon to ParseSchema
 - Adds Parse Server Health Check
 - Adds ability to Request Verification Emails
-- Adds the ability to set/save in `ParseConfig` 
+- Adds the ability to set/save in `ParseConfig`
 - Adds `ParseLogs`
 - Adds `ParseAudience`
 - Adds jobs to `ParseCloud`
@@ -34,5 +34,5 @@ Here are some of the major changes that were made in this release.
 - Support for managing indexes via **ParseSchema** (thanks to [Diamond Lewis](https://github.com/dplewis))
 
 You can find more detail regarding these changes on the [1.4.0 release page](https://github.com/parse-community/parse-php-sdk/releases/tag/1.4.0).
-As always we hope you enjoy these new features. If you have any questions feel free to reach out to us on [github](https://github.com/parse-community/parse-php-sdk) and let us know what you think. 
+As always we hope you enjoy these new features. If you have any questions feel free to reach out to us on [github](https://github.com/parse-community/parse-php-sdk) and let us know what you think.
 We're always open to improving parse server and it's sdks for the community!

--- a/_posts/2018-01-01-happy-new-years.md
+++ b/_posts/2018-01-01-happy-new-years.md
@@ -4,7 +4,7 @@ title: Happy New Year!
 date: 2018-01-01 11:16 -0700
 comments: true
 author: montymxb
-categories: [parse, community, new year]
+categories: [community, New Year]
 ---
 
 We'd like to take a moment to say thank you to everyone in the community and beyond.

--- a/_posts/2018-01-01-happy-new-years.md
+++ b/_posts/2018-01-01-happy-new-years.md
@@ -4,7 +4,7 @@ title: Happy New Year!
 date: 2018-01-01 11:16 -0700
 comments: true
 author: montymxb
-categories: [community, New Year]
+categories: [Community, New Year]
 ---
 
 We'd like to take a moment to say thank you to everyone in the community and beyond.

--- a/_posts/2018-08-15-JS-SDK.md
+++ b/_posts/2018-08-15-JS-SDK.md
@@ -4,7 +4,7 @@ title: The JS SDK hits version 2.0
 date: 2018-08-15 15:16 -0400
 comments: true
 author: flovilmart
-categories: [announcements, javascript, sdk]
+categories: [Announcements, JavaScript, SDK]
 ---
 
 The summer has been really busy and we've dusted off the JS SDK, stripping out large parts of its legacy. `Parse.Promises` and `Backbone` style callbacks are definitely out.

--- a/blog/categories/community.html
+++ b/blog/categories/community.html
@@ -1,0 +1,8 @@
+---
+layout: blog
+permalink: /blog/categories/community/
+pagination:
+    enabled: true
+    category: Community
+    permalink: /:num/
+---

--- a/blog/categories/github.html
+++ b/blog/categories/github.html
@@ -1,0 +1,8 @@
+---
+layout: blog
+permalink: /blog/categories/github/
+pagination:
+    enabled: true
+    category: GitHub
+    permalink: /:num/
+---

--- a/blog/categories/javascript.html
+++ b/blog/categories/javascript.html
@@ -1,0 +1,8 @@
+---
+layout: blog
+permalink: /blog/categories/javascript/
+pagination:
+    enabled: true
+    category: JavaScript
+    permalink: /:num/
+---

--- a/blog/categories/new-year.html
+++ b/blog/categories/new-year.html
@@ -1,0 +1,8 @@
+---
+layout: blog
+permalink: /blog/categories/new-year/
+pagination:
+    enabled: true
+    category: New Year
+    permalink: /:num/
+---

--- a/blog/categories/new-year.html
+++ b/blog/categories/new-year.html
@@ -1,6 +1,6 @@
 ---
 layout: blog
-permalink: /blog/categories/new-year/
+permalink: /blog/categories/new year/
 pagination:
     enabled: true
     category: New Year

--- a/blog/categories/nodejs.html
+++ b/blog/categories/nodejs.html
@@ -1,0 +1,8 @@
+---
+layout: blog
+permalink: /blog/categories/nodejs/
+pagination:
+    enabled: true
+    category: NodeJS
+    permalink: /:num/
+---

--- a/blog/categories/notice.html
+++ b/blog/categories/notice.html
@@ -1,0 +1,8 @@
+---
+layout: blog
+permalink: /blog/categories/notice/
+pagination:
+    enabled: true
+    category: Notice
+    permalink: /:num/
+---

--- a/blog/categories/php.html
+++ b/blog/categories/php.html
@@ -1,0 +1,8 @@
+---
+layout: blog
+permalink: /blog/categories/php/
+pagination:
+    enabled: true
+    category: PHP
+    permalink: /:num/
+---

--- a/blog/categories/release.html
+++ b/blog/categories/release.html
@@ -1,0 +1,8 @@
+---
+layout: blog
+permalink: /blog/categories/release/
+pagination:
+    enabled: true
+    category: Release
+    permalink: /:num/
+---

--- a/blog/categories/sdk.html
+++ b/blog/categories/sdk.html
@@ -1,0 +1,8 @@
+---
+layout: blog
+permalink: /blog/categories/sdk/
+pagination:
+    enabled: true
+    category: SDK
+    permalink: /:num/
+---

--- a/blog/categories/security.html
+++ b/blog/categories/security.html
@@ -1,0 +1,8 @@
+---
+layout: blog
+permalink: /blog/categories/security/
+pagination:
+    enabled: true
+    category: Security
+    permalink: /:num/
+---

--- a/blog/categories/update.html
+++ b/blog/categories/update.html
@@ -1,0 +1,8 @@
+---
+layout: blog
+permalink: /blog/categories/update/
+pagination:
+    enabled: true
+    category: Update
+    permalink: /:num/
+---


### PR DESCRIPTION
- Added a bunch of new categories that seem appropriate or have already been used multiple times
- Removed some categories that have only been used once and/or seem pointless - i.e. version number tags (these are unlikely to be used multiple times so serve little purpose)
- Standardised the capitalisation of tags on posts
- Added section on categories in the README