### PR TITLE
Added tweet button to posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -42,7 +42,10 @@ layout: page
             <!-- Twitter cards metadata -->
             <meta name="twitter:card" content="summary">
             <meta name="twitter:site" content="@ParsePlatform">
-            <meta name="twitter:creator" content="@{{author.twitter}}">
+
+            {% if author.twitter %}
+              <meta name="twitter:creator" content="@{{author.twitter}}">
+            {% endif %}
 
             {% if page.title %}
               <meta name="twitter:title" content="{{ page.title }}">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -14,17 +14,20 @@ layout: page
 {% else %}
   <meta name="twitter:title" content="{{ site.title }}">
 {% endif %}
+
 {% if page.url %}
   <meta name="twitter:url" content="{{ site.url }}{{ page.url }}">
 {% endif %}
-{% if page.description %}
-  <meta name="twitter:description" content="{{ page.description }}">
+
+{% if page.excerpt %}
+  <meta name="twitter:description" content="{{ page.excerpt | strip_html }}">
 {% else %}
   <meta name="twitter:description" content="{{ site.description }}">
 {% endif %}
-{% if page.header-img %}
+
+<!-- {% if page.header-img %}
   <meta name="twitter:image:src" content="{{ site.url }}/{{ page.header-img }}">
-{% endif %}
+{% endif %} -->
 
 <aside class="hero hero--docs-landing">
     <div class="grid-container">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -73,7 +73,7 @@ layout: page
               {% assign authorName = author.name %}
             {% endif %}
 
-            <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-size="large" data-text="{{ page.title }} by {{ authorName }}" data-via="ParsePlatform" data-hashtags="ParsePlatform" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+            <a class="btn btn--outline" href="https://twitter.com/intent/tweet?hashtags=ParsePlatform&original_referer={{ site.url }}{{ page.url }}&ref_src=twsrc%5Etfw&text={{ page.title }} by {{ authorName }}&tw_p=tweetbutton&url={{ site.url }}{{ page.url }}&via=ParsePlatform">Tweet this post 2</a>
 
         </div>
     </article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -36,6 +36,7 @@ layout: page
                 <span class="margin-left-10 margin-right-10"><a href="{{ author.site }}">Site</a></span>
                 {% endif %}
             </div>
+            <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-size="large" data-via="ParsePlatform" data-hashtags="ParsePlatform" data-related="ParsePlatform" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
         </div>
     </article>
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -60,7 +60,9 @@ layout: page
                 <span class="margin-left-10 margin-right-10"><a href="{{ author.site }}">Site</a></span>
                 {% endif %}
             </div>
-            <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-size="large" data-via="ParsePlatform" data-hashtags="ParsePlatform" data-related="ParsePlatform" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+
+            <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-size="large" data-text="{{ page.title }} by @{{ author.twitter }}" data-via="ParsePlatform" data-hashtags="ParsePlatform" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+
         </div>
     </article>
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -73,7 +73,7 @@ layout: page
               {% assign authorName = author.name %}
             {% endif %}
 
-            <a class="btn btn--outline" href="https://twitter.com/intent/tweet?hashtags=ParsePlatform&original_referer={{ site.url }}{{ page.url }}&ref_src=twsrc%5Etfw&text={{ page.title }} by {{ authorName }}&tw_p=tweetbutton&url={{ site.url }}{{ page.url }}&via=ParsePlatform">Tweet this post 2</a>
+            <a class="btn btn--outline btn--twitter" href="https://twitter.com/intent/tweet?hashtags=ParsePlatform&original_referer={{ site.url }}{{ page.url }}&ref_src=twsrc%5Etfw&text={{ page.title }} by {{ authorName }}&tw_p=tweetbutton&url={{ site.url }}{{ page.url }}&via=ParsePlatform">Tweet this post</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
         </div>
     </article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,6 +1,28 @@
 ---
 layout: page
 ---
+
+<!-- Twitter cards metadata -->
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@vdaubry">
+<meta name="twitter:creator" content="@vdaubry">
+{% if page.title %}
+  <meta name="twitter:title" content="{{ page.title }}">
+{% else %}
+  <meta name="twitter:title" content="{{ site.title }}">
+{% endif %}
+{% if page.url %}
+  <meta name="twitter:url" content="{{ site.url }}{{ page.url }}">
+{% endif %}
+{% if page.description %}
+  <meta name="twitter:description" content="{{ page.description }}">
+{% else %}
+  <meta name="twitter:description" content="{{ site.description }}">
+{% endif %}
+{% if page.header-img %}
+  <meta name="twitter:image:src" content="{{ site.url }}/{{ page.header-img }}">
+{% endif %}
+
 <aside class="hero hero--docs-landing">
     <div class="grid-container">
         <div class="col--9">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -60,9 +60,7 @@ layout: page
               <meta name="twitter:description" content="{{ site.description }}">
             {% endif %}
 
-            <!-- {% if page.header-img %}
-              <meta name="twitter:image:src" content="{{ site.url }}/{{ page.header-img }}">
-            {% endif %} -->
+            <meta name="twitter:image" content="https://blog.parseplatform.org/img/favicon/apple-touch-icon-144x144.png">
 
             {% assign authorName = "" %}
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,31 +4,6 @@ layout: page
 
 {% assign author = site.authors[page.author] %}
 
-<!-- Twitter cards metadata -->
-<meta name="twitter:card" content="summary">
-<meta name="twitter:site" content="@ParsePlatform">
-<meta name="twitter:creator" content="@{{author.twitter}}">
-
-{% if page.title %}
-  <meta name="twitter:title" content="{{ page.title }}">
-{% else %}
-  <meta name="twitter:title" content="{{ site.title }}">
-{% endif %}
-
-{% if page.url %}
-  <meta name="twitter:url" content="{{ site.url }}{{ page.url }}">
-{% endif %}
-
-{% if page.excerpt %}
-  <meta name="twitter:description" content="{{ page.excerpt | strip_html }}">
-{% else %}
-  <meta name="twitter:description" content="{{ site.description }}">
-{% endif %}
-
-<!-- {% if page.header-img %}
-  <meta name="twitter:image:src" content="{{ site.url }}/{{ page.header-img }}">
-{% endif %} -->
-
 <aside class="hero hero--docs-landing">
     <div class="grid-container">
         <div class="col--9">
@@ -63,6 +38,31 @@ layout: page
                 <span class="margin-left-10 margin-right-10"><a href="{{ author.site }}">Site</a></span>
                 {% endif %}
             </div>
+
+            <!-- Twitter cards metadata -->
+            <meta name="twitter:card" content="summary">
+            <meta name="twitter:site" content="@ParsePlatform">
+            <meta name="twitter:creator" content="@{{author.twitter}}">
+
+            {% if page.title %}
+              <meta name="twitter:title" content="{{ page.title }}">
+            {% else %}
+              <meta name="twitter:title" content="{{ site.title }}">
+            {% endif %}
+
+            {% if page.url %}
+              <meta name="twitter:url" content="{{ site.url }}{{ page.url }}">
+            {% endif %}
+
+            {% if page.excerpt %}
+              <meta name="twitter:description" content="{{ page.excerpt | strip_html }}">
+            {% else %}
+              <meta name="twitter:description" content="{{ site.description }}">
+            {% endif %}
+
+            <!-- {% if page.header-img %}
+              <meta name="twitter:image:src" content="{{ site.url }}/{{ page.header-img }}">
+            {% endif %} -->
 
             {% assign authorName = "" %}
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -64,7 +64,15 @@ layout: page
                 {% endif %}
             </div>
 
-            <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-size="large" data-text="{{ page.title }} by @{{ author.twitter }}" data-via="ParsePlatform" data-hashtags="ParsePlatform" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+            {% assign authorName = "" %}
+
+            {% if author.twitter %}
+              {% capture authorName %}@{{author.twitter}}{% endcapture %}
+            {% else %}
+              {% assign authorName = author.name %}
+            {% endif %}
+
+            <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-size="large" data-text="{{ page.title }} by {{ authorName }}" data-via="ParsePlatform" data-hashtags="ParsePlatform" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
         </div>
     </article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,10 +2,13 @@
 layout: page
 ---
 
+{% assign author = site.authors[page.author] %}
+
 <!-- Twitter cards metadata -->
 <meta name="twitter:card" content="summary">
-<meta name="twitter:site" content="@vdaubry">
-<meta name="twitter:creator" content="@vdaubry">
+<meta name="twitter:site" content="@ParsePlatform">
+<meta name="twitter:creator" content="@{{author.twitter}}">
+
 {% if page.title %}
   <meta name="twitter:title" content="{{ page.title }}">
 {% else %}
@@ -27,7 +30,6 @@ layout: page
     <div class="grid-container">
         <div class="col--9">
             <div class="hero--docs-landing__content">
-                {% assign author = site.authors[page.author] %}
                 {% assign postdate = page.date %}
                 {% include posts/author.html %}
                 <h1 class="h1 h1--white">

--- a/css/lib/marketing/components/_buttons.scss
+++ b/css/lib/marketing/components/_buttons.scss
@@ -76,6 +76,11 @@
         }
     }
 
+    &--twitter{
+      margin-top: 20px;
+      border-radius: 20px;
+    }
+
     &--inverse,
     &--white{
         background: white;


### PR DESCRIPTION
I have added a custom tweet button to post.html along with metadata tags to create tags for the tweets generated from the buttons. - this works automatically for _all_ posts on the blog

I've also added a new twitter button style to _buttons.scss - it could be improved (i.e by adding a twitter logo) but I think it looks pretty good for now and matches the existing style of the website better than the default twitter buttons:

<img width="775" alt="screenshot 2019-03-05 at 21 55 37" src="https://user-images.githubusercontent.com/13188249/53840212-70653700-3f91-11e9-95b5-2ee0d30cef39.png">

Tweet example (ignore start of url - I was using (Ngrok)[https://ngrok.com] to test):

<img width="596" alt="screenshot 2019-03-05 at 21 57 12" src="https://user-images.githubusercontent.com/13188249/53840316-b4f0d280-3f91-11e9-8d67-43132e4a15b3.png">

The only known issue is that, for some reason, one on the the posts I tested the image of the Parse Platform logo wasn't displayed but I don't think this is a major issue for now. I did see on some stack overflow post that twitter removes the image if it is the same as another tweet from the same website (as they don't want generic images on cards) but I found this inconclusive in practice and many sites seem to use generic images anyway 🙃