### PR TITLE
Quick fix for #15

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -54,7 +54,7 @@ layout: page
             {% endif %}
 
             {% if page.url %}
-              <meta name="twitter:url" content="{{ site.url }}{{ page.url }}">
+              <meta name="twitter:url" content="http://blog.parseplatform.org{{ page.url }}">
             {% endif %}
 
             {% if page.excerpt %}
@@ -73,7 +73,7 @@ layout: page
               {% assign authorName = author.name %}
             {% endif %}
 
-            <a class="btn btn--outline btn--twitter" href="https://twitter.com/intent/tweet?hashtags=ParsePlatform&original_referer={{ site.url }}{{ page.url }}&ref_src=twsrc%5Etfw&text={{ page.title }} by {{ authorName }}&tw_p=tweetbutton&url={{ site.url }}{{ page.url }}&via=ParsePlatform">Tweet this post</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+            <a class="btn btn--outline btn--twitter" href="https://twitter.com/intent/tweet?hashtags=ParsePlatform&original_referer=http://blog.parseplatform.org{{ page.url }}&ref_src=twsrc%5Etfw&text={{ page.title }} by {{ authorName }}&tw_p=tweetbutton&url=http://blog.parseplatform.org{{ page.url }}&via=ParsePlatform">Tweet this post</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
         </div>
     </article>


### PR DESCRIPTION
In #15 the urls generated for the tweet button had an extra forward slash - this doesn't break the links but means that twitter doesn't generate the cards.

e.g.

http://blog.parseplatform.org//announcements/javascript/sdk/2018/08/15/JS-SDK.html should be http://blog.parseplatform.org/announcements/javascript/sdk/2018/08/15/JS-SDK.html

My local host didn't have a slash at the end of the Jekyll variable `site.url` so didn't notice this when testing 🤦‍♂️ 