### PR TITLE
Multiple word categories & cleaning up categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ The current list of categories:
 - Security
 - Update
 - Videos
+- Tutorial
+- Open-Source
+- Hacktoberfest
+- Engineering
+- Design
 
 If you would like to use a new category please make a new file in the [categories folder](blog/categories), for example:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ More info can be found in the [official docs](http://jekyllrb.com/docs/posts/).
 
 ## Using categories & adding new ones
 
-When adding a category to a blog post please remember to capitalize words.
+When adding a category to a blog post please remember to capitalize words. For categories with multiple words please separate words with dashes instead of spaces eg. New-Year not New Year.
 
 The current list of categories:
 - Announcements
@@ -65,7 +65,7 @@ The current list of categories:
 - GitHub
 - JavaScript
 - Learn
-- New Year
+- New-Year
 - NodeJS
 - Notice
 - PHP

--- a/_posts/2014-01-03-award-winning-badland-app-uses-parse-for-android.md
+++ b/_posts/2014-01-03-award-winning-badland-app-uses-parse-for-android.md
@@ -10,7 +10,6 @@ dsq_thread_id:
   - "3687613973"
 categories:
   - Customers
-  - Non-Technical
 tags:
   - EMEA
 ---

--- a/_posts/2014-01-31-grand-interactive-builds-biotechnology-apps-with-parse.md
+++ b/_posts/2014-01-31-grand-interactive-builds-biotechnology-apps-with-parse.md
@@ -10,7 +10,6 @@ dsq_thread_id:
   - "3738046131"
 categories:
   - Customers
-  - Non-Technical
 tags:
   - US
 ---

--- a/_posts/2014-02-10-slots-house-of-fun-uses-parse-for-effective-push-engagement.md
+++ b/_posts/2014-02-10-slots-house-of-fun-uses-parse-for-effective-push-engagement.md
@@ -10,7 +10,6 @@ dsq_thread_id:
   - "3687614162"
 categories:
   - Customers
-  - Non-Technical
 tags:
   - EMEA
 ---

--- a/_posts/2014-02-13-parse-facebook-at-developerweek-2014.md
+++ b/_posts/2014-02-13-parse-facebook-at-developerweek-2014.md
@@ -10,7 +10,6 @@ dsq_thread_id:
   - "3709042194"
 categories:
   - Events
-  - Non-Technical
 ---
 The Parse + Facebook team is heading to <a href="http://developerweek.com/" target="_blank">DeveloperWeek</a> in San Francisco next week, and we have lots of great events around the conference for you to attend! Check out our schedule of DeveloperWeek events below:
 

--- a/_posts/2014-02-14-dayre-long-form-blogging-simplified.md
+++ b/_posts/2014-02-14-dayre-long-form-blogging-simplified.md
@@ -10,7 +10,6 @@ dsq_thread_id:
   - "3688874071"
 categories:
   - Customers
-  - Non-Technical
 tags:
   - APAC
 ---

--- a/_posts/2014-02-22-savings-com-uses-parse-to-power-favado-grocery-savings-app.md
+++ b/_posts/2014-02-22-savings-com-uses-parse-to-power-favado-grocery-savings-app.md
@@ -10,7 +10,6 @@ dsq_thread_id:
   - "3704192875"
 categories:
   - Customers
-  - Non-Technical
 tags:
   - US
 ---

--- a/_posts/2014-02-28-new-musx-app-from-savvy-apps-makes-music-sharing-simple.md
+++ b/_posts/2014-02-28-new-musx-app-from-savvy-apps-makes-music-sharing-simple.md
@@ -10,7 +10,6 @@ dsq_thread_id:
   - "3707596628"
 categories:
   - Customers
-  - Non-Technical
 tags:
   - US
 ---

--- a/_posts/2014-03-07-deer-hunter-2014-on-facebook-with-parse.md
+++ b/_posts/2014-03-07-deer-hunter-2014-on-facebook-with-parse.md
@@ -10,7 +10,6 @@ dsq_thread_id:
   - "3687556860"
 categories:
   - Customers
-  - Non-Technical
 tags:
   - US
 ---

--- a/_posts/2014-03-14-russian-developers-build-township-on-parse.md
+++ b/_posts/2014-03-14-russian-developers-build-township-on-parse.md
@@ -10,7 +10,6 @@ dsq_thread_id:
   - "3687614256"
 categories:
   - Customers
-  - Non-Technical
 tags:
   - EMEA
 ---
@@ -23,5 +22,5 @@ The game uses Parse Data to store players’ profiles. Using Parse in this way i
 Township was launched on iOS in late 2013 and on Google Play early in 2014. In just over three months, the game achieved almost 4 million downloads with a healthy retention, allowing the game to grow organically and achieve a 4.5 star rating across 80,000 reviews on both the iTunes App Store and Google Play.
 
 _You can download Township for free on the <a href="https://itunes.apple.com/app/id638689075" target="_blank">iTunes App Store</a>, <a href="https://play.google.com/store/apps/details?id=com.playrix.township" target="_blank">Google Play</a>, and <a href="http://www.amazon.com/Playrix-Township/dp/B00IG2DOKM/" target="_blank">Amazon</a> and play online on <a href="https://apps.facebook.com/township/" target="_blank">Facebook</a>.
-  
+
 _

--- a/_posts/2014-03-21-concrete-software-uses-parse-for-push-in-pba-bowling-challenge.md
+++ b/_posts/2014-03-21-concrete-software-uses-parse-for-push-in-pba-bowling-challenge.md
@@ -10,7 +10,6 @@ dsq_thread_id:
   - "3687615180"
 categories:
   - Customers
-  - Non-Technical
 tags:
   - US
 ---

--- a/_posts/2014-03-26-cyberagent-uses-parse-push-to-power-pashaoku-auction-app.md
+++ b/_posts/2014-03-26-cyberagent-uses-parse-push-to-power-pashaoku-auction-app.md
@@ -10,7 +10,6 @@ dsq_thread_id:
   - "3687615193"
 categories:
   - Customers
-  - Non-Technical
 tags:
   - APAC
   - Japan
@@ -26,7 +25,7 @@ The team working on Pashaoku turned to Parse when they started looking for a ser
 In addition to push, Pashaoku also stores targeting data in Parse. App developer Caesar Wirth, an iOS and Android developer who worked on the iOS version of Pashaoku, explains that, “Since Parse is so flexible, it is easy to add or remove targeting criteria. We keep Parse synchronized with our own database, so everything is always up to date.” After using Parse in Pashaoku, Caesar continues:
 
 > I am a big fan of the data querying system and history log. We send pushes to certain subsets of users, and some of our queries can get a little complex. Parse handles it all. Afterwards, we can look back and see everything we sent, and to whom, so we can reproduce anything we want.
-> 
+>
 > Parse provides such a stable and flexible infrastructure, that it would take many man hours to develop something internal. With the correct strategy, you could probably have something up and running within a matter of days as opposed to weeks. Even a free account provides many of the benefits.
 
 With 520K+ downloads on <a href="https://itunes.apple.com/jp/app/pashaoku/id536462239?l=ja&ls=1&mt=8" target="_blank">iOS</a> and 300K+ on <a href="https://play.google.com/store/apps/details?id=jp.cyberagent.pashaoku" target="_blank">Android</a>, Pashaoku is still going strong long after its initial release. You can learn more about <a href="http://www.cyberagent.co.jp/en/" target="_blank">CyberAgent</a> and the story behind its success <a href="http://systemsofexchange.org/2014/03/cyberagent/" target="_blank">here</a>.

--- a/_posts/2014-03-27-efficient-parse-queries.md
+++ b/_posts/2014-03-27-efficient-parse-queries.md
@@ -10,7 +10,6 @@ dsq_thread_id:
   - "3687773395"
 categories:
   - Engineering
-  - Ops
 ---
 Any time you store objects on Parse, they get stored on a database. Usually, a database stores a bag of data on disk, and when you issue Parse queries it looks up the data and returns the matching objects. Since it doesn't make sense for the database to look at all the data present in a particular Parse class for every query, the database uses something called an index. An index is a sorted list of items matching a given criteria. Indexes help because they allow the database to do an efficient search and return matching results without looking at all of the data. For the more algorithmically inclined, this is an _O(log(n)) vs O(n)_ tradeoff. Indexes are typically smaller in size and fit in memory, resulting in faster lookups.
 

--- a/_posts/2014-03-28-fox-international-channels-uses-parse-push-to-keep-audiences-engaged.md
+++ b/_posts/2014-03-28-fox-international-channels-uses-parse-push-to-keep-audiences-engaged.md
@@ -16,7 +16,6 @@ hide_from_index:
   - "0"
 categories:
   - Customers
-  - Non-Technical
 tags:
   - LATAM
 ---

--- a/_posts/2014-04-01-smart-indexing-at-parse.md
+++ b/_posts/2014-04-01-smart-indexing-at-parse.md
@@ -10,7 +10,6 @@ dsq_thread_id:
   - "3687483692"
 categories:
   - Engineering
-  - Ops
 ---
 We love running databases at Parse! We also believe that mobile app developers shouldn't have to be DBAs to build beautiful, performant apps.
 

--- a/_posts/2014-04-04-meme-inc-uses-parse-in-top-grossing-xtreme-slots.md
+++ b/_posts/2014-04-04-meme-inc-uses-parse-in-top-grossing-xtreme-slots.md
@@ -16,7 +16,6 @@ hide_from_index:
   - "0"
 categories:
   - Customers
-  - Non-Technical
 tags:
   - US
 ---

--- a/_posts/2014-04-18-showtime-turns-to-parse-to-power-next-gen-tv-experiences.md
+++ b/_posts/2014-04-18-showtime-turns-to-parse-to-power-next-gen-tv-experiences.md
@@ -10,7 +10,6 @@ dsq_thread_id:
   - "3687614671"
 categories:
   - Customers
-  - Non-Technical
 tags:
   - US
 ---

--- a/_posts/2014-04-25-redtape-design-builds-alicia-keys-vault-with-parse.md
+++ b/_posts/2014-04-25-redtape-design-builds-alicia-keys-vault-with-parse.md
@@ -16,7 +16,6 @@ hide_from_index:
   - "0"
 categories:
   - Customers
-  - Non-Technical
 tags:
   - US
 ---

--- a/_posts/2014-04-30-parse-pricing-now-cheaper-and-simpler.md
+++ b/_posts/2014-04-30-parse-pricing-now-cheaper-and-simpler.md
@@ -19,7 +19,6 @@ dsq_thread_id:
 image: /wp-content/uploads/2014/04/Blog-post-Pricing.png
 categories:
   - Announcements
-  - Non-Technical
 tags:
   - pricing
 ---
@@ -60,7 +59,7 @@ Moving forward, there won't be different 'tiers' of Parse. There's only one type
       </li>
     </ul>
   </li>
-  
+
   <li>
     Parse Push <ul class="standard-list">
       <li>
@@ -71,7 +70,7 @@ Moving forward, there won't be different 'tiers' of Parse. There's only one type
       </li>
     </ul>
   </li>
-  
+
   <li>
     Parse Analytics <ul class="standard-list">
       <li>

--- a/_posts/2014-05-13-dependency-injection-with-go.md
+++ b/_posts/2014-05-13-dependency-injection-with-go.md
@@ -16,7 +16,6 @@ dsq_thread_id:
   - "3679500557"
 categories:
   - Engineering
-  - Ops
 tags:
   - go
 ---

--- a/_posts/2014-05-23-orbitz-app-uses-parse-push-analytics-and-core-to-keep-users-updated.md
+++ b/_posts/2014-05-23-orbitz-app-uses-parse-push-analytics-and-core-to-keep-users-updated.md
@@ -16,7 +16,6 @@ dsq_thread_id:
   - "3678794636"
 categories:
   - Customers
-  - Non-Technical
 tags:
   - analytics
   - push

--- a/_posts/2014-06-20-fun-with-tokumx.md
+++ b/_posts/2014-06-20-fun-with-tokumx.md
@@ -10,7 +10,6 @@ dsq_thread_id:
   - "3678708617"
 categories:
   - Engineering
-  - Ops
 ---
 **[TokuMX](http://www.tokutek.com/)** is an open source distribution of MongoDB that replaces the default B-tree data structure with a [fractal tree index](http://www.tokutek.com/resources/technology/), which can lead to dramatic improvements in data storage size and write speeds. [Mark Callaghan](http://www.blogger.com/profile/09590445221922043181) made a series of awesome [blog posts](http://smalldatum.blogspot.com/) on benchmarking InnoDB, TokuMX and MongoDB, which demonstrate TokuMX's remarkable write performance and extraordinarily efficient space utilization. We decided to benchmark TokuMX against several real-world scenarios that we encountered in the Parse environment. We also built a set of tools for capturing and replaying query streams. We are open sourcing these tools on [github](https://github.com/ParsePlatform/flashback) so that others may also benefit from them (we'll discuss more about them in the last section).
 
@@ -20,7 +19,7 @@ In our benchmarks, we tested three aspects of TokuMX: 1. Exporting and importin
 
 * * *
 
-## 
+##
 
 We frequently need to migrate data by exporting and importing collections between replica sets. However, this process can be painful because sometimes the migration rate is ridiculously slow, especially for collections with a lot of small entries and/or complicated indexes. To test importing and exporting, we performed an import/export on two representative large collections with varying object counts.
 
@@ -55,7 +54,7 @@ TokuMX            53 minutes</pre>
 
 * * *
 
-## 
+##
 
 One of our sample write-intensive apps issues a heavy volume of “update” requests with large object sizes. Since TokuMX is a write-optimized database, we decided to benchmark this query stream against both MongoDB and TokuMX. We recorded 10 hours of sample traffic, and replayed it against both replica sets. From the benchmark results, TokuMX performs 3x faster for this app with much smaller latencies at all histogram percentiles.
 
@@ -83,7 +82,7 @@ One of our sample write-intensive apps issues a heavy volume of “update” req
 
 * * *
 
-## 
+##
 
 Space efficiency is another big selling point for TokuMX. How much can TokuMX save in terms of disk utilization? To figure this out, we exported the data of one of our shared replica sets (with 2.4T ****data in total) and imported them into TokuMX instances. The result was stunning: TokuMX used only 379G disk space —**about 15% of the original size.**
 

--- a/_posts/2015-04-30-mongodb-rocksdb-benchmark-setup-compression.md
+++ b/_posts/2015-04-30-mongodb-rocksdb-benchmark-setup-compression.md
@@ -18,7 +18,6 @@ dsq_thread_id:
   - "3725884852"
 categories:
   - Engineering
-  - Ops
 tags:
   - mongodb
   - RocksDB

--- a/_posts/2015-05-15-phone-based-login-can-you-dig-it.md
+++ b/_posts/2015-05-15-phone-based-login-can-you-dig-it.md
@@ -19,7 +19,6 @@ feature_image_style:
 image: /wp-content/uploads/2015/05/AnyPhone-hero.jpg
 categories:
   - Announcements
-  - Sample App
 tags:
   - anyphone
   - cloudcode

--- a/_posts/2015-09-04-strata-open-source-library-for-efficient-mongodb-backups.md
+++ b/_posts/2015-09-04-strata-open-source-library-for-efficient-mongodb-backups.md
@@ -16,7 +16,6 @@ dsq_thread_id:
   - "4095638922"
 categories:
   - Engineering
-  - Ops
 tags:
   - go
   - mongodb

--- a/_posts/2016-03-01-what-is-parse-server.md
+++ b/_posts/2016-03-01-what-is-parse-server.md
@@ -18,7 +18,7 @@ image: /wp-content/uploads/2016/01/Open-DB-Launch.png
 categories:
   - Announcements
 tags:
-  - open source
+  - Open-Source
 ---
 In this post, I will attempt to convince you that <a href="https://github.com/ParsePlatform/parse-server" target="_blank">Parse Server</a> is worthy of your time and interest, even if you've never heard of Parse before. I will also make the case that <a href="https://github.com/ParsePlatform/parse-server" target="_blank">Parse Server</a> is and can be objectively better than the hosted Parse service. I hope that by the end of it, you will consider evaluating it for your next project.
 

--- a/_posts/2016-04-18-parse-server-video-series-april-2016.md
+++ b/_posts/2016-04-18-parse-server-video-series-april-2016.md
@@ -16,8 +16,7 @@ categories:
   - Learn
   - Tutorial
 tags:
-  - open source
-  - tutorial
+  - Tutorial
 ---
 We're really excited about the community which is forming around Parse Server and Parse Dashboard. In just 80 days since we launched Parse Server, more than 60 contributors from all over the world have already taken part. Parse Server is one of the most active open-source projects at Facebook, and growing incredibly quickly. This month we're releasing a group of screencasts we hope will be helpful to developers looking to get started with Parse Server. We'll span the process from setting up your development environment and running your first app, to migrating your database and even submitting changes on the open-source repository. We will also talk about JavaScript, testing, and code reviews. Let's get started!
 

--- a/_posts/2018-01-01-happy-new-years.md
+++ b/_posts/2018-01-01-happy-new-years.md
@@ -4,7 +4,7 @@ title: Happy New Year!
 date: 2018-01-01 11:16 -0700
 comments: true
 author: montymxb
-categories: [Community, New Year]
+categories: [Community, New-Year]
 ---
 
 We'd like to take a moment to say thank you to everyone in the community and beyond.

--- a/blog/categories/design.html
+++ b/blog/categories/design.html
@@ -1,0 +1,8 @@
+---
+layout: blog
+permalink: /blog/categories/design/
+pagination:
+    enabled: true
+    category: Design
+    permalink: /:num/
+---

--- a/blog/categories/engineering.html
+++ b/blog/categories/engineering.html
@@ -1,0 +1,8 @@
+---
+layout: blog
+permalink: /blog/categories/engineering/
+pagination:
+    enabled: true
+    category: Engineering
+    permalink: /:num/
+---

--- a/blog/categories/hacktoberfest.html
+++ b/blog/categories/hacktoberfest.html
@@ -1,0 +1,8 @@
+---
+layout: blog
+permalink: /blog/categories/hacktoberfest/
+pagination:
+    enabled: true
+    category: Hacktoberfest
+    permalink: /:num/
+---

--- a/blog/categories/new-year.html
+++ b/blog/categories/new-year.html
@@ -1,8 +1,8 @@
 ---
 layout: blog
-permalink: /blog/categories/new year/
+permalink: /blog/categories/new-year/
 pagination:
     enabled: true
-    category: New Year
+    category: New-Year
     permalink: /:num/
 ---

--- a/blog/categories/open-source.html
+++ b/blog/categories/open-source.html
@@ -1,0 +1,8 @@
+---
+layout: blog
+permalink: /blog/categories/open-source/
+pagination:
+    enabled: true
+    category: Open-Source
+    permalink: /:num/
+---

--- a/blog/categories/tutorial.html
+++ b/blog/categories/tutorial.html
@@ -1,0 +1,8 @@
+---
+layout: blog
+permalink: /blog/categories/tutorial/
+pagination:
+    enabled: true
+    category: Tutorial
+    permalink: /:num/
+---


### PR DESCRIPTION
Fixes an issue where multiple word tags with spaces in between words would break the urls for the tweet button. Multiple word categories are now separated using dashes

I've also gone through all the posts in the _posts folder and removed all redundant categories and added new category files to fix broken links