### PR TITLE
gems config option renamed to plugins

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,7 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: http://blog.parseplatform.org/ # the base hostname & protocol for your site, e.g. http://example.com
 
 # Gems
-gems:
+plugins:
   - jekyll-paginate-v2
 
 whitelist:


### PR DESCRIPTION
From the [logs of the last commit](https://github.com/parse-community/blog/runs/1926729190)...

> Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.